### PR TITLE
Use of getDerivedStateFromProps instead of componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,11 +100,13 @@ export class Animated extends React.Component {
     this.state = props.animateOnMount ? this.getNewState(props) : {};
   }
 
-  componentWillReceiveProps(nextProps) {
-    const {isVisible} = this.props;
-    if (isVisible !== nextProps.isVisible) {
-      this.setState(this.getNewState({...this.props, ...nextProps}));
+  static getDerivedStateFromProps (nextProps, prevState) {
+    const { isVisible: nextIsVisible } = nextProps
+    const { isVisible: prevIsVisible } = prevState
+    if (nextIsVisible !== prevIsVisible) {
+      return this.getNewState({...this.props, ...nextProps});
     }
+    return {}
   }
 
   getNewState = ({

--- a/src/index.js
+++ b/src/index.js
@@ -104,12 +104,12 @@ export class Animated extends React.Component {
     const { isVisible: nextIsVisible } = nextProps
     const { isVisible: prevIsVisible } = prevState
     if (nextIsVisible !== prevIsVisible) {
-      return this.getNewState({...this.props, ...nextProps});
+      return this.getNewState({...prevState, ...nextProps});
     }
     return {}
   }
 
-  getNewState = ({
+  static getNewState = ({
                    isVisible,
                    animationIn,
                    animationOut,


### PR DESCRIPTION
Solution to **From React 17.x.x componentWillReceiveProps will be deprecated and a different strategy is introduced.**